### PR TITLE
Changed /bot command to /merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bot which enables or disable [`auto-merge`](https://docs.github.com/en/pull-requ
 
 This action was developed to help external parties merge their own Pull Requests.
 
-If an external party makes a PR, and it is approved, they still can not merge it. This bot gives them the ability to enable the `auto-merge` function so, once their PR gets approved, it is merged.
+If an external party makes a PR, and it is approved, they still cannot merge it. This bot gives them the ability to enable the `auto-merge` function so, once their PR gets approved, it is merged.
 
 ## Configuration
 Be sure that **Allow auto-merge** is enabled in the repository options.
@@ -23,8 +23,8 @@ on:
 jobs:
   set-auto-merge:
     runs-on: ubuntu-latest
-    # Important! This forces the job to run only on comments on Pull Requests that starts with '/bot'
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/bot') }}
+    # Important! This forces the job to run only on comments on Pull Requests that starts with '/merge'
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge') }}
     steps:
       - name: Set auto merge
         uses: paritytech/auto-merge-bot@main
@@ -47,12 +47,12 @@ You can find all the inputs in [the action file](./action.yml), but let's walk t
 ## Usage
 
 To trigger the bot, you need to write a comment in a Pull Request where the action is installed. The available actions are:
-- `/bot merge`: Enables auto-merge for Pull Request
-- `/bot cancel`: Cancels auto-merge for Pull Request
-- `/bot help`: Shows this menu
+- `/merge`: Enables auto-merge for Pull Request
+- `/merge cancel`: Cancels auto-merge for Pull Request
+- `/merge help`: Shows this menu
 
 The bot can only be triggered by the author of the PR or by users who *publicly* belongs to the organization of the repository.
 
 By publicly, I refer to the members of an organization which can be seen by external parties. If you are not sure if you are part of an organization, simply open https://github.com/orgs/**your_organization**/people in a private window. If you don’t see your name there, you are not a public member.
 
-Find related docs here: [ Publicizing or hiding organization membership](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership).
+Find related docs here: [Publicizing or hiding organization membership](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership).

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -4,16 +4,16 @@ import { CommentsApi } from "./github/comments";
 import { Merger } from "./github/merger";
 import { ActionLogger } from "./github/types";
 
-const BOT_COMMAND = "/bot";
+const BOT_COMMAND = "/merge";
 
 type Command = "merge" | "cancel" | "help";
 
 const botCommands = `
 **Available commands**
 
-- \`/bot merge\`: Enables auto-merge for Pull Request
-- \`/bot cancel\`: Cancels auto-merge for Pull Request
-- \`/bot help\`: Shows this menu
+- \`/merge\`: Enables auto-merge for Pull Request
+- \`/merge cancel\`: Cancels auto-merge for Pull Request
+- \`/merge help\`: Shows this menu
 
 For more information see the [documentation](https://github.com/paritytech/auto-merge-bot)
 `;
@@ -73,13 +73,15 @@ export class Bot {
     const [_, command] = this.comment.body.split(" ");
     try {
       switch (command as Command) {
-        case "merge":
+        // Simply `/merge`
+        case undefined:
           await this.commentsApi.reactToComment(this.comment.id, "+1");
           await merger.enableAutoMerge();
           await this.commentsApi.comment(
             "Enabled `auto-merge` in Pull Request",
           );
           break;
+        // `/merge cancel`
         case "cancel":
           await this.commentsApi.reactToComment(this.comment.id, "+1");
           await merger.disableAutoMerge();
@@ -87,9 +89,11 @@ export class Bot {
             "Disabled `auto-merge` in Pull Request",
           );
           break;
+        // `/merge help`
         case "help":
           await this.commentsApi.comment("## Auto-Merge-Bot\n" + botCommands);
           break;
+        // `/merge anything else`
         default: {
           await this.commentsApi.reactToComment(this.comment.id, "confused");
           await this.commentsApi.comment(


### PR DESCRIPTION
Changed command to /merge

New commands are:
- `/merge`: Enables auto-merge for Pull Request
- `/merge cancel`: Cancels auto-merge for Pull Request
- `/merge help`: Shows this menu

This resolves #8