### PR TITLE
Added commenting of errors

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -115,7 +115,8 @@ export class Bot {
       await this.commentsApi.comment(
         "### There was a problem running the action.\n\n" +
           "❌😵❌\n\n" +
-          `Please see more at the [logs](${this.actionUrl})`,
+          `Please find more information in the [logs](${this.actionUrl}).`,
+        true,
       );
       throw e;
     }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -25,7 +25,7 @@ export class Bot {
     private readonly logger: ActionLogger,
     private readonly commentsApi: CommentsApi,
     private readonly actionUrl: string,
-  ) { }
+  ) {}
 
   /** Verifies if the author is the author of the PR or a member of the org */
   async canTriggerBot(): Promise<boolean> {
@@ -112,7 +112,11 @@ export class Bot {
       this.logger.error(e as Error);
 
       // If possible, let's try to comment about an issue
-      await this.commentsApi.comment("There was a problem running the action.\n\n" + "❌😵❌" + `Please see more at the [logs](${this.actionUrl})`)
+      await this.commentsApi.comment(
+        "### There was a problem running the action.\n\n" +
+          "❌😵❌\n\n" +
+          `Please see more at the [logs](${this.actionUrl})`,
+      );
       throw e;
     }
   }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -24,7 +24,8 @@ export class Bot {
     private readonly pr: Issue,
     private readonly logger: ActionLogger,
     private readonly commentsApi: CommentsApi,
-  ) {}
+    private readonly actionUrl: string,
+  ) { }
 
   /** Verifies if the author is the author of the PR or a member of the org */
   async canTriggerBot(): Promise<boolean> {
@@ -109,6 +110,9 @@ export class Bot {
       }
     } catch (e) {
       this.logger.error(e as Error);
+
+      // If possible, let's try to comment about an issue
+      await this.commentsApi.comment("There was a problem running the action.\n\n" + "❌😵❌" + `Please see more at the [logs](${this.actionUrl})`)
       throw e;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ logger.info(
   }`,
 );
 
+const actionUrl = `${context.serverUrl}/${repo.owner}/${repo.repo}/actions/runs/${context.runId}`;
+
 if (context.payload.comment) {
   const token = getInput("GITHUB_TOKEN", { required: true });
   const comment = context.payload.comment as unknown as IssueComment;

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ if (context.payload.comment) {
     headers: { authorization: `token ${token}` },
   }) as graphql;
   const merger = new Merger(issue.node_id, gql, logger, getMergeMethod());
-  const bot = new Bot(comment, issue, logger, commentsApi);
+  const bot = new Bot(comment, issue, logger, commentsApi, actionUrl);
   bot
     .run(merger)
     .then(() => logger.info("Finished!"))


### PR DESCRIPTION
Added a call to the comment function inside the `catch` block.

Just to be sure, we are logging the error first in the case that the comment fails.

The intention is that, if it fails for a configuration reason, the bot will be able to report that. (If it fails because of the commenting feature then it won't be able to report it).

A good example is that it is set for `MERGE` but it is not allowed in the repository (or `auto-merge` is disabled).

This resolves #2