### PR TITLE
Merge PR when checks are ready

### DIFF
--- a/src/github/merger.ts
+++ b/src/github/merger.ts
@@ -19,6 +19,7 @@ mutation($prId: ID!) {
     }
 }`;
 
+// https://docs.github.com/en/graphql/reference/mutations#mergepullrequest
 export const MERGE_PULL_REQUEST = `
 mutation($prId: ID!, $mergeMethod: PullRequestMergeMethod!) {
   mergePullRequest(input: {pullRequestId: $prId, mergeMethod: $mergeMethod}) {
@@ -46,6 +47,7 @@ export class Merger {
       });
       this.logger.info("Succesfully enabled auto-merge");
     } catch (error) {
+      this.logger.warn(error as Error);
       if (
         error instanceof Error &&
         error.message.includes("Pull request is in clean status")

--- a/src/github/merger.ts
+++ b/src/github/merger.ts
@@ -19,6 +19,13 @@ mutation($prId: ID!) {
     }
 }`;
 
+export const MERGE_PULL_REQUEST = `
+mutation($prId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+  mergePullRequest(input: {pullRequestId: $prId, mergeMethod: $mergeMethod}) {
+      clientMutationId
+  }
+}`;
+
 export type MergeMethod = "SQUASH" | "MERGE" | "REBASE";
 
 export class Merger {

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -1,6 +1,10 @@
 import { validate } from "@octokit/graphql-schema";
 
-import { DISABLE_AUTO_MERGE, ENABLE_AUTO_MERGE, MERGE_PULL_REQUEST } from "../github/merger";
+import {
+  DISABLE_AUTO_MERGE,
+  ENABLE_AUTO_MERGE,
+  MERGE_PULL_REQUEST,
+} from "../github/merger";
 
 describe("Schemas", () => {
   test("ENABLE_AUTO_MERGE", () => {

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -1,6 +1,6 @@
 import { validate } from "@octokit/graphql-schema";
 
-import { DISABLE_AUTO_MERGE, ENABLE_AUTO_MERGE } from "../github/merger";
+import { DISABLE_AUTO_MERGE, ENABLE_AUTO_MERGE, MERGE_PULL_REQUEST } from "../github/merger";
 
 describe("Schemas", () => {
   test("ENABLE_AUTO_MERGE", () => {
@@ -9,5 +9,9 @@ describe("Schemas", () => {
 
   test("DISABLE_AUTO_MERGE", () => {
     expect(validate(DISABLE_AUTO_MERGE)).toEqual([]);
+  });
+
+  test("MERGE_PULL_REQUEST", () => {
+    expect(validate(MERGE_PULL_REQUEST)).toEqual([]);
   });
 });


### PR DESCRIPTION
There is an issue that you can not enable `auto-merge` when a PR is ready to merge.

For this situation, I have added a try/catch block where it evaluates if the error contains the message `Pull request is in clean status`. If so, it will use the [mergePullRequest](https://docs.github.com/en/graphql/reference/mutations#mergepullrequest) mutation to merge the PR directly.

This fixes #12