### PR TITLE
Continuous deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Publish package to GitHub Packages
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  IMAGE_NAME: action
+  REGISTRY: ghcr.io
+
+jobs:
+  test-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - name: Check that the image builds
+        run: docker build . --file Dockerfile
+  validate-action:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v3.3.0
+      # This checks that .github/workflows/review-bot.yml is pointing towards the main branch
+      # as, during development, we change this to use the code from the test branch and
+      # we may forget to set it back to main
+      - name: Validate that action points to main branch
+        run: |
+          BRANCH=$(yq '.jobs.review-approvals.steps[1].uses' $FILE_NAME | cut -d "@" -f2)
+          # If the branch is not the main branch
+          if [ "$BRANCH" != "$GITHUB_BASE_REF" ]; then
+            echo "Action points to $BRANCH. It has to point to $GITHUB_BASE_REF instead!"
+            exit 1
+          else
+            echo "Action is correctly pointing to $GITHUB_BASE_REF"
+          fi
+        env:
+          FILE_NAME: ".github/workflows/auto-merge-bot.yml"
+
+  compare-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.verification.outputs.VERSION }}
+      exists: ${{ steps.package_version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - name: Extract package.json version
+        id: package_version
+        run: echo "VERSION=$(jq '.version' -r package.json)" >> $GITHUB_OUTPUT
+        # Compare that the versions contain the same name
+      - name: Compare versions
+        id: verification
+        uses: Bullrich/compare-version-on-action@main
+        with:
+          version: ${{ steps.package_version.outputs.VERSION }}
+        # Verifies if there is a tag with that version number
+      - uses: mukunku/tag-exists-action@v1.4.0
+        if: steps.verification.outputs.VERSION
+        id: checkTag
+        with: 
+          tag: v${{ steps.package_version.outputs.VERSION }}
+
+  publish:
+    if: github.event_name == 'push' && needs.compare-versions.outputs.exists == 'false'
+    needs: [test-image, compare-versions]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - name: Tag version and create release
+        run: gh release create $VERSION --generate-notes
+        env:
+          VERSION: ${{ needs.compare-versions.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          tags: ${{ needs.compare-versions.outputs.version }}
+      - uses: actions/checkout@v3
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       # we may forget to set it back to main
       - name: Validate that action points to main branch
         run: |
-          BRANCH=$(yq '.jobs.review-approvals.steps[1].uses' $FILE_NAME | cut -d "@" -f2)
+          BRANCH=$(yq '.jobs.set-auto-merge.steps[0].uses' $FILE_NAME | cut -d "@" -f2)
           # If the branch is not the main branch
           if [ "$BRANCH" != "$GITHUB_BASE_REF" ]; then
             echo "Action points to $BRANCH. It has to point to $GITHUB_BASE_REF instead!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.verification.outputs.VERSION }}
-      exists: ${{ steps.package_version.outputs.VERSION }}
+      exists: ${{ steps.checkTag.outputs.exists }}
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Extract package.json version

--- a/README.md
+++ b/README.md
@@ -61,3 +61,14 @@ The bot can only be triggered by the author of the PR or by users who *publicly*
 By publicly, I refer to the members of an organization which can be seen by external parties. If you are not sure if you are part of an organization, simply open https://github.com/orgs/**your_organization**/people in a private window. If you don’t see your name there, you are not a public member.
 
 Find related docs here: [Publicizing or hiding organization membership](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership).
+
+## Deployment
+
+To deploy a new version you need to update two files:
+- [`package.json`](./package.json): Update the version number.
+- [`action.yml`](./action.yml): Update the image number in `runs.image`.
+**Important**: Both versions must have the same number.
+
+When a commit is pushed to the main branch and the versions have changed, the system will automatically tag the commit and release a new package with such version.
+
+You can find all the available versions in the [release section](./releases).


### PR DESCRIPTION
Created deploy script to automatically deploy new versions to GitHub packages using Docker.

This resolves #4

I changed a bit my formula and cleaned up the code quite a lot. The publish method has been merged into one (originally it was one to tag and one to deploy, but using `gh` I could minimize the footprint).